### PR TITLE
Allow assignment in conditional statements if wrapped in parantheses

### DIFF
--- a/base.js
+++ b/base.js
@@ -64,7 +64,7 @@ module.exports = {
     "no-case-declarations": 2,
     "no-catch-shadow": 0,
     "no-class-assign": 2,
-    "no-cond-assign": [2, "always"],
+    "no-cond-assign": [2, "except-parens"],
     "no-confusing-arrow": 2,
     "no-console": 2,
     "no-const-assign": 2,


### PR DESCRIPTION
Currently, there is no sane way to do the following:

``` js
const fooReg = /foo: "(.*?)"/g
const matchStr = 'foo: "bar", foo: "baz"';

let match = null
while ((match = fooReg.exec(matchStr))) {
  // do something
}
```

As it breaks the `no-cond-assign` rule. You could use other looping methods, but they usually involve duplicating assignment logic etc.
