### PR TITLE
Switch off the array-element-newline rule

### DIFF
--- a/base.js
+++ b/base.js
@@ -12,7 +12,7 @@ module.exports = {
     "array-bracket-newline": ["error", { "multiline": true }],
     "arrow-body-style": "off",
     "array-callback-return": "error",
-    "array-element-newline": ["error", { "multiline": true }],
+    "array-element-newline": "off",
     "arrow-parens": ["error", "as-needed"],
     "arrow-spacing": "error",
     "block-scoped-var": "error",


### PR DESCRIPTION
I suggest we switch this off, because it disallows breaking up large arrays over several lines.